### PR TITLE
Fix TypeError on constraint wires using bezier option

### DIFF
--- a/NodeEditor.py
+++ b/NodeEditor.py
@@ -416,8 +416,14 @@ class NodeEditorWindow(QtWidgets.QMainWindow):
         if not self.source_node or not self.target_node:
             return
 
-        def draw_line(source_port, target_port, color, connection_type):
-            line = WireLine(source_port.scenePos(), target_port.scenePos(), color=color, connection_type=connection_type)
+        def draw_line(source_port, target_port, color, connection_type, bezier=False):
+            line = WireLine(
+                source_port.scenePos(),
+                target_port.scenePos(),
+                color=color,
+                connection_type=connection_type,
+                bezier=bezier,
+            )
             line.connected_ports = [source_port, target_port]
             self.scene.addItem(line)
             self.scene.wire_items.append(line)


### PR DESCRIPTION
## Summary
- Allow `sync_connections_from_maya` to draw constraint wires using the bezier option
- Forward bezier flag to `WireLine` so constraint lines render properly

## Testing
- `python -m py_compile NodeEditor.py`


------
https://chatgpt.com/codex/tasks/task_e_68988b20d978832fbbea5fedfb4fb0e4